### PR TITLE
Update style of curve map, add more customization

### DIFF
--- a/js-projects/icos-leaflet-map/atm_curve.html
+++ b/js-projects/icos-leaflet-map/atm_curve.html
@@ -22,6 +22,13 @@
 <body>
 	<div id="map"></div>
 	<script type="text/javascript">
+		const mapSettings = {zoom: 2, coords: [68, 15], allowZoom: true};
+		const factor = 0.7;
+		L.Icon.Default.prototype.options.iconSize = L.Icon.Default.prototype.options.iconSize.map(x => x*factor);
+		L.Icon.Default.prototype.options.iconAnchor = L.Icon.Default.prototype.options.iconAnchor.map(x => x*factor);
+		L.Icon.Default.prototype.options.popupAnchor = L.Icon.Default.prototype.options.popupAnchor.map(x => x*factor);
+		L.Icon.Default.prototype.options.shadowSize = L.Icon.Default.prototype.options.shadowSize.map(x => x*factor);
+		L.Icon.Default.prototype.options.tooltipAnchor = L.Icon.Default.prototype.options.tooltipAnchor.map(x => x*factor);
 	const sparqlQuery =`prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
 prefix prov: <http://www.w3.org/ns/prov#>
 select ?station ?lat ?lon ?name ?cc where {

--- a/js-projects/icos-leaflet-map/index.html
+++ b/js-projects/icos-leaflet-map/index.html
@@ -22,6 +22,7 @@
 <body>
 	<div id="map"></div>
 	<script type="text/javascript">
+		const mapSettings = {};
 	const sparqlQuery =`PREFIX cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT ?station ?lat ?lon ?name ?cc

--- a/js-projects/icos-leaflet-map/main.js
+++ b/js-projects/icos-leaflet-map/main.js
@@ -1,9 +1,10 @@
+const zoomSetting = mapSettings.allowZoom ?? false;
 const map = L.map('map', {
-	zoomControl: false,
-	doubleClickZoom: false,
-	scrollWheelZoom: false,
-	touchZoom: false
-}).setView([58, 15], 4);
+	zoomControl: zoomSetting,
+	doubleClickZoom: zoomSetting,
+	scrollWheelZoom: zoomSetting,
+	touchZoom: zoomSetting
+}).setView(mapSettings.coords ?? [58, 15], mapSettings.zoom ?? 4);
 
 initMap();
 


### PR DESCRIPTION
Allows for the curve map to have smaller icons with different zoom/center settings, and enables zoom controls within the map, while keeping the JS generic and not altering the appearance of the default map.

Within its intended size, which has fixed height and changeable width, the map can then show all of the stations included in the curve app, as below:

<img width="626" height="472" alt="image" src="https://github.com/user-attachments/assets/27e9968e-e02c-418f-82c3-1bc6e01ff723" />

May want to consider doing something differently in the future for a more unified mapping tool, but this will work for now.