### PR TITLE
Ensure Matomo loads before cookie consent pushes to it

### DIFF
--- a/js-projects/cookie-consent/cookieconsent-config.js
+++ b/js-projects/cookie-consent/cookieconsent-config.js
@@ -16,19 +16,36 @@ CookieConsent.run({
 				matomo: {
 					label: 'Matomo',
 					onAccept: () => {
-						let totalTime = 0;
-						function pushPaq() {
-							if(_paq) {
-								clearInterval(paqRetry);
-								_paq.push(['setCookieConsentGiven']);
-							} else {
-								totalTime += 1000;
-								if (totalTime > 60000) {
-									clearInterval(paqRetry);
+						let waitingTime = 0;
+						function acceptMatomo() {
+							if (typeof _paq === "undefined") {
+								waitingTime += 250;
+								if (waitingTime > 10000) {
+									clearInterval(acceptRetry);
 								}
+							} else {
+								clearInterval(acceptRetry);
+								_paq.push(['setCookieConsentGiven']);
+								_paq.push(['rememberCookieConsentGiven']);
 							}
 						}
-						const paqRetry = setInterval(pushPaq, 1000);
+						const acceptRetry = setInterval(acceptMatomo, 250);
+					},
+					onReject: () => {
+						let waitingTime = 0;
+						function rejectMatomo() {
+							if (typeof _paq === "undefined") {
+								waitingTime += 250;
+								if (waitingTime > 10000) {
+									clearInterval(rejectRetry);
+								}
+							} else {
+								clearInterval(rejectRetry);
+								_paq.push(['forgetCookieConsentGiven']);  
+								_paq.push(['deleteCookies']);
+							}
+						}
+						const rejectRetry = setInterval(rejectMatomo, 250);
 					}
 				}
 			}

--- a/js-projects/cookie-consent/cookieconsent-config.js
+++ b/js-projects/cookie-consent/cookieconsent-config.js
@@ -16,10 +16,16 @@ CookieConsent.run({
 				matomo: {
 					label: 'Matomo',
 					onAccept: () => {
+						let totalTime = 0;
 						function pushPaq() {
 							if(_paq) {
 								clearInterval(paqRetry);
 								_paq.push(['setCookieConsentGiven']);
+							} else {
+								totalTime += 1000;
+								if (totalTime > 60000) {
+									clearInterval(paqRetry);
+								}
 							}
 						}
 						const paqRetry = setInterval(pushPaq, 1000);

--- a/js-projects/cookie-consent/cookieconsent-config.js
+++ b/js-projects/cookie-consent/cookieconsent-config.js
@@ -16,7 +16,13 @@ CookieConsent.run({
 				matomo: {
 					label: 'Matomo',
 					onAccept: () => {
-						_paq.push(['setCookieConsentGiven']);
+						function pushPaq() {
+							if(_paq) {
+								clearInterval(paqRetry);
+								_paq.push(['setCookieConsentGiven']);
+							}
+						}
+						const paqRetry = setInterval(pushPaq, 1000);
 					}
 				}
 			}


### PR DESCRIPTION
Right now we are (sometimes) getting a console error on production and next because the cookie consent is trying to push to Matomo before Matomo is actually loaded.

We can avoid this by ensuring `_paq` is available before pushing the cookie consent to it. This will also ensure Matomo works consistently, and there's no race condition between when scripts are loaded. (To be fair, it is probably less of an issue when you use cached scripts, but still better to ensure it's there before pushing to it.)

I don't love the polling method here, but the interval is pretty long (1 second), so it should have minimal impact on efficiency. If `_paq` is never actually loaded, e.g. if someone's privacy blocker blocks Matomo, then the interval will be cleared after a minute.

This can be deployed prior to publication of new website.